### PR TITLE
Improve pipe support by changing to os.isatty(0)

### DIFF
--- a/mdvl.py
+++ b/mdvl.py
@@ -470,7 +470,7 @@ def sys_main():
     except Exception as ex:
         err = str(ex)
         cols = 80
-    if S_ISFIFO(os.fstat(0).st_mode): # pipe mode
+    if not os.isatty(0): # pipe mode
         md = sys.stdin.read()
     else:
         if not len(sys.argv) > 1 or '-h' in sys.argv:


### PR DESCRIPTION
Cool library you have here!

What worked before:

So, I see in the readme that content can be piped to the script and that works fine.
`cat FILE.md | ./mdvl.py`

However, if I accept input from a file it should also become stdin.
`./mdvl.py < FILE.md`

As explained here https://stackoverflow.com/a/35248103

Disclaimer, I'm not good at python, there might be side-effects to this change. Would be great with a code review, thanks! 🌟 